### PR TITLE
bypass OPTIONS method

### DIFF
--- a/aiohttp_basicauth_middleware/__init__.py
+++ b/aiohttp_basicauth_middleware/__init__.py
@@ -48,6 +48,9 @@ def check_access(auth_dict: dict, header_value: str, strategy: Callable = lambda
 def basic_auth_middleware(urls: Iterable, auth_dict: dict, strategy: Callable = lambda x: x) -> Coroutine:
     async def factory(app, handler):
         async def middleware(request):
+            if request.method == 'OPTIONS':
+                return await handler(request)
+            
             for url in urls:
                 if not request.path.startswith(url):
                     continue


### PR DESCRIPTION
Hello, I encountered a problem.
I request APIs by JavaScript on FireFox, I find OPTIONS requests are **Unauthorized 401**.
OPTIONS request is generated by browsers and is paired with GET, POST and etc.
I solved problem by bypass OPTIONS request. Please check it's safe way or another way, thanks.